### PR TITLE
CLD-766 Add unix socket to root config file

### DIFF
--- a/templates/root-my.cnf.j2
+++ b/templates/root-my.cnf.j2
@@ -3,3 +3,4 @@
 [client]
 user="{{ mysql_root_username }}"
 password="{{ mysql_root_password }}"
+socket="{{ mysql_socket }}"


### PR DESCRIPTION
**Summary**

Fix error caused by unable to connect to MariaDB using root credentials by instead using unix socket connection root access.

**Tests**
```
PLAY RECAP ********************************************************************************************
keycloak-db-controller002-dev.core-x.net : ok=43   changed=15   unreachable=0    failed=0    skipped=16   rescued=0    ignored=0
```